### PR TITLE
Remove add services functionality from booking history

### DIFF
--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -41,7 +41,6 @@ import {
   RefreshCw,
   Star,
   ArrowLeft,
-  Plus,
   Package,
   CreditCard,
   User,

--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -823,20 +823,6 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
         />
       )}
 
-      {/* Add Services Modal */}
-      {addingServicesBooking && (
-        <EditBookingModal
-          isOpen={showAddServicesModal}
-          onClose={() => {
-            setShowAddServicesModal(false);
-            setAddingServicesBooking(null);
-          }}
-          booking={addingServicesBooking}
-          onSave={handleSaveAddedServices}
-          mode="add-services"
-        />
-      )}
-
       {/* Contact Support Dialog */}
       <Dialog open={showContactDialog} onOpenChange={setShowContactDialog}>
         <DialogContent className="sm:max-w-md">

--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -67,8 +67,7 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
   const [refreshing, setRefreshing] = useState(false);
   const [editingBooking, setEditingBooking] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
-  const [addingServicesBooking, setAddingServicesBooking] = useState(null);
-  const [showAddServicesModal, setShowAddServicesModal] = useState(false);
+
   const [cancellingBooking, setCancellingBooking] = useState<string | null>(
     null,
   );
@@ -347,72 +346,6 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
         createErrorNotification(
           "Update Failed",
           "Failed to update booking. Please try again.",
-        ),
-      );
-    }
-  };
-
-  const handleAddServices = (booking: any) => {
-    if (!canEditBooking(booking)) {
-      addNotification(
-        createWarningNotification(
-          "Cannot Add Services",
-          "Services cannot be added to this booking in its current status",
-        ),
-      );
-      return;
-    }
-    setAddingServicesBooking(booking);
-    setShowAddServicesModal(true);
-  };
-
-  const handleSaveAddedServices = async (updatedBooking: any) => {
-    try {
-      const bookingService = BookingService.getInstance();
-      const bookingId = updatedBooking.id || updatedBooking._id;
-
-      const result = await bookingService.updateBooking(
-        bookingId,
-        updatedBooking,
-      );
-
-      if (result.success) {
-        // Update local state
-        setBookings((prev) =>
-          prev.map((booking: any) =>
-            booking.id === bookingId || booking._id === bookingId
-              ? {
-                  ...booking,
-                  ...updatedBooking,
-                  updatedAt: new Date().toISOString(),
-                }
-              : booking,
-          ),
-        );
-
-        setShowAddServicesModal(false);
-        setAddingServicesBooking(null);
-
-        addNotification(
-          createSuccessNotification(
-            "Services Added",
-            "Services have been added to your booking successfully",
-          ),
-        );
-      } else {
-        addNotification(
-          createErrorNotification(
-            "Update Failed",
-            result.error || "Failed to add services",
-          ),
-        );
-      }
-    } catch (error) {
-      console.error("Error adding services:", error);
-      addNotification(
-        createErrorNotification(
-          "Update Failed",
-          "Failed to add services. Please try again.",
         ),
       );
     }

--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -838,20 +838,6 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
                                 </AlertDialogContent>
                               </AlertDialog>
                             )}
-
-                            {canEditBooking(booking) && (
-                              <Button
-                                onClick={() => handleAddServices(booking)}
-                                variant="outline"
-                                className="flex items-center justify-center gap-2 border-blue-200 text-blue-600 hover:bg-blue-50 py-2"
-                                size="sm"
-                              >
-                                <Plus className="h-3 w-3 sm:h-4 sm:w-4" />
-                                <span className="text-xs sm:text-sm">
-                                  Add Services
-                                </span>
-                              </Button>
-                            )}
                           </div>
 
                           {/* Contact Support */}

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -222,52 +222,6 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
     await cancelBooking(bookingId);
   };
 
-  const handleSaveAddedServices = async (updatedBooking: any) => {
-    try {
-      // Update the booking with new services
-      const { data, error } = await adaptiveBookingHelpers.updateBooking(
-        updatedBooking._id || updatedBooking.id,
-        updatedBooking,
-      );
-
-      if (error) {
-        addNotification(
-          createErrorNotification(
-            "Update Failed",
-            `Failed to add services: ${error.message}`,
-          ),
-        );
-        return;
-      }
-
-      // Update the bookings list
-      const updatedBookings = bookings.map((booking: any) =>
-        (booking._id || booking.id) ===
-        (updatedBooking._id || updatedBooking.id)
-          ? updatedBooking
-          : booking,
-      );
-
-      setBookings(updatedBookings);
-      setShowAddServicesModal(false);
-      setAddingServicesBooking(null);
-      addNotification(
-        createSuccessNotification(
-          "Services Added",
-          "Services have been added to your booking successfully!",
-        ),
-      );
-    } catch (error) {
-      console.error("Error adding services:", error);
-      addNotification(
-        createErrorNotification(
-          "Update Failed",
-          "Failed to add services. Please try again.",
-        ),
-      );
-    }
-  };
-
   const canCancelBooking = (booking: any) => {
     const bookingDate = new Date(booking.scheduled_date);
     const now = new Date();

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -56,8 +56,6 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
   const [refreshing, setRefreshing] = useState(false);
   const [editingBooking, setEditingBooking] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
-  const [addingServicesBooking, setAddingServicesBooking] = useState(null);
-  const [showAddServicesModal, setShowAddServicesModal] = useState(false);
 
   const loadBookings = async () => {
     if (!currentUser?.id && !currentUser?._id && !currentUser?.phone) {
@@ -222,11 +220,6 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
 
   const handleCancelBooking = async (bookingId: string) => {
     await cancelBooking(bookingId);
-  };
-
-  const handleAddServices = (booking: any) => {
-    setAddingServicesBooking(booking);
-    setShowAddServicesModal(true);
   };
 
   const handleSaveAddedServices = async (updatedBooking: any) => {
@@ -1026,20 +1019,6 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
           }}
           booking={editingBooking}
           onSave={handleSaveEditedBooking}
-        />
-      )}
-
-      {/* Add Services Modal */}
-      {addingServicesBooking && (
-        <EditBookingModal
-          isOpen={showAddServicesModal}
-          onClose={() => {
-            setShowAddServicesModal(false);
-            setAddingServicesBooking(null);
-          }}
-          booking={addingServicesBooking}
-          onSave={handleSaveAddedServices}
-          mode="add-services"
         />
       )}
     </div>

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -34,7 +34,6 @@ import {
   RefreshCw,
   Star,
   ArrowLeft,
-  Plus,
 } from "lucide-react";
 import { BookingService } from "@/services/bookingService";
 import { adaptiveBookingHelpers } from "@/integrations/adaptive/bookingHelpers";

--- a/src/components/ServiceEditor.tsx
+++ b/src/components/ServiceEditor.tsx
@@ -109,7 +109,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
     return () => clearTimeout(timer);
   }, [services]);
 
-
   const updateServiceQuantity = (index: number, newQuantity: number) => {
     if (newQuantity <= 0) {
       removeService(index);
@@ -245,7 +244,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
         {/* Available Services Grid */}
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-full">
-
           {availableServices.map((service) => {
             const isSelected = services.some((s) => s.name === service.name);
 
@@ -264,7 +262,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
                 }}
               >
                 <CardContent className="p-3">
-
                   <div className="flex items-start justify-between gap-2">
                     <div className="flex-1 min-w-0 overflow-hidden">
                       <h4 className="font-medium text-sm text-gray-900 mb-1 break-words">
@@ -303,7 +300,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
                       >
                         <Plus className="h-3 w-3" />
                       </Button>
-
                     </div>
                   </div>
                 </CardContent>
@@ -311,49 +307,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
             );
           })}
         </div>
-
-        {/* Custom Service */}
-        <Card className="border-dashed border-gray-300">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base">Add Custom Service</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <Label htmlFor="service-name" className="text-sm">
-                  Service Name
-                </Label>
-                <Input
-                  id="service-name"
-                  placeholder="e.g., Special Cleaning"
-                  value={newServiceName}
-                  onChange={(e) => setNewServiceName(e.target.value)}
-                />
-              </div>
-              <div>
-                <Label htmlFor="service-price" className="text-sm">
-                  Price (₹)
-                </Label>
-                <Input
-                  id="service-price"
-                  type="number"
-                  placeholder="35"
-                  value={newServicePrice}
-                  onChange={(e) => setNewServicePrice(e.target.value)}
-                />
-              </div>
-            </div>
-            <Button
-              type="button"
-              onClick={addCustomService}
-              disabled={!newServiceName.trim()}
-              className="w-full"
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Add Custom Service
-            </Button>
-          </CardContent>
-        </Card>
       </div>
 
       {/* Total */}

--- a/src/components/ServiceEditor.tsx
+++ b/src/components/ServiceEditor.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+
 import {
   Plus,
   Minus,

--- a/src/components/ServiceEditor.tsx
+++ b/src/components/ServiceEditor.tsx
@@ -34,8 +34,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
   mode,
 }) => {
   const [services, setServices] = useState<ServiceItem[]>([]);
-  const [newServiceName, setNewServiceName] = useState("");
-  const [newServicePrice, setNewServicePrice] = useState("");
 
   // Laundry services that users can add
   const availableServices = [
@@ -139,16 +137,6 @@ const ServiceEditor: React.FC<ServiceEditorProps> = ({
       const newService = { name: serviceName, quantity: 1, price };
       setServices([...services, newService]);
     }
-  };
-
-  const addCustomService = () => {
-    if (!newServiceName.trim()) return;
-
-    const price = parseFloat(newServicePrice) || 35;
-    const newService = { name: newServiceName.trim(), quantity: 1, price };
-    setServices([...services, newService]);
-    setNewServiceName("");
-    setNewServicePrice("");
   };
 
   return (


### PR DESCRIPTION
Remove the "Add Services" feature from booking history components.

Changes made:
- Removed Plus icon import from both EnhancedBookingHistory and MobileBookingHistory components
- Removed state variables for adding services modal (addingServicesBooking, showAddServicesModal)
- Removed handleAddServices and handleSaveAddedServices functions
- Removed "Add Services" button from booking action buttons
- Removed AddServicesModal component rendering
- Removed custom service addition functionality from ServiceEditor component
- Removed Input and Label imports from ServiceEditor
- Removed custom service form fields and addCustomService function

The booking history components now focus on viewing, editing, and canceling existing bookings without the ability to add new services to existing bookings.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/70e50ad23f584cbaa6497075c217a631/zen-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>70e50ad23f584cbaa6497075c217a631</projectId>-->
<!--<branchName>zen-hub</branchName>-->