### PR TITLE
Add expandable card view to booking history

### DIFF
--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -66,6 +66,7 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
   const [refreshing, setRefreshing] = useState(false);
   const [editingBooking, setEditingBooking] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [expandedCard, setExpandedCard] = useState<string | null>(null);
 
   const [cancellingBooking, setCancellingBooking] = useState<string | null>(
     null,
@@ -538,7 +539,7 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
             </CardContent>
           </Card>
         ) : (
-          <div className="space-y-3 sm:space-y-6">
+          <div className="space-y-3">
             {bookings.map((booking: any, index) => {
               const bookingId = booking.id || booking._id || `booking_${index}`;
               const services = Array.isArray(booking.services)
@@ -548,301 +549,358 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> = ({
               const hasRealId =
                 !!(booking.id || booking._id) &&
                 !bookingId.startsWith("booking_");
+              const isExpanded = expandedCard === bookingId;
+
+              const toggleExpand = () => {
+                setExpandedCard(isExpanded ? null : bookingId);
+              };
 
               return (
                 <Card
                   key={bookingId}
-                  className="overflow-hidden border border-gray-200 shadow-lg hover:shadow-xl transition-shadow duration-300"
+                  className="overflow-hidden border border-gray-200 shadow-sm hover:shadow-md transition-all duration-200 cursor-pointer"
+                  onClick={toggleExpand}
                 >
-                  <CardHeader className="bg-gradient-to-r from-gray-50 to-blue-50 border-b border-gray-200 p-3 sm:p-6">
-                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-4">
-                      <div className="flex-1">
-                        <CardTitle className="text-lg sm:text-xl font-bold text-gray-900 mb-1 sm:mb-2">
-                          {booking.service || "Home Service"}
-                        </CardTitle>
-                        <p className="text-xs sm:text-sm text-blue-600 font-medium">
-                          by {booking.provider_name || "HomeServices Pro"}
-                        </p>
+                  {/* Compact Card Header - Always Visible */}
+                  <CardHeader className="pb-2 px-3 py-3 bg-gradient-to-r from-green-50 to-blue-50">
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="font-semibold text-sm text-gray-900 truncate">
+                            {booking.service || "Home Service"}
+                          </h3>
+                          <Badge
+                            className={`${getStatusColor(booking.status)} text-xs px-1.5 py-0.5`}
+                          >
+                            {booking.status || "pending"}
+                          </Badge>
+                        </div>
+
+                        {/* Quick Info Row */}
+                        <div className="flex items-center gap-3 text-xs text-gray-600">
+                          <div className="flex items-center gap-1">
+                            <Package className="h-3 w-3" />
+                            <span>
+                              {services.length} item
+                              {services.length > 1 ? "s" : ""}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            <span>
+                              {formatDate(
+                                booking.pickupDate || booking.scheduled_date,
+                              )}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            <span>
+                              {booking.pickupTime ||
+                                booking.scheduled_time ||
+                                "10:00"}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1 text-green-600 font-semibold">
+                            <span>₹{total}</span>
+                          </div>
+                        </div>
                       </div>
-                      <Badge
-                        className={`${getStatusColor(booking.status)} border font-medium flex items-center gap-1`}
-                      >
-                        {getStatusIcon(booking.status)}
-                        <span className="capitalize">
-                          {booking.status || "pending"}
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-400">
+                          {isExpanded ? "Less" : "More"}
                         </span>
-                      </Badge>
+                        <div
+                          className={`transform transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+                        >
+                          <svg
+                            className="h-4 w-4 text-gray-400"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M19 9l-7 7-7-7"
+                            />
+                          </svg>
+                        </div>
+                      </div>
                     </div>
                   </CardHeader>
 
-                  <CardContent className="p-3 sm:p-6 space-y-3 sm:space-y-6">
-                    {/* Services */}
-                    <div>
-                      <h4 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
-                        <Package className="h-4 w-4 text-blue-600" />
-                        Booked Services
-                      </h4>
-                      <div className="space-y-2">
-                        {services.map((service: any, idx: number) => {
-                          const serviceName =
-                            typeof service === "object"
-                              ? service.name || service.service
-                              : service;
-                          const quantity =
-                            typeof service === "object"
-                              ? service.quantity || 1
-                              : 1;
+                  {/* Expanded Content - Only Visible When Expanded */}
+                  {isExpanded && (
+                    <CardContent
+                      className="px-3 pb-3 pt-2 space-y-3 bg-white"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {/* Services Detail */}
+                      <div className="bg-blue-50 p-3 rounded-lg">
+                        <h4 className="font-semibold text-gray-900 mb-2 text-sm flex items-center gap-2">
+                          <Package className="h-4 w-4 text-blue-600" />
+                          Services Ordered
+                        </h4>
+                        <div className="space-y-1">
+                          {services.map((service: any, idx: number) => {
+                            const serviceName =
+                              typeof service === "object"
+                                ? service.name || service.service
+                                : service;
+                            const quantity =
+                              typeof service === "object"
+                                ? service.quantity || 1
+                                : 1;
+                            const price =
+                              typeof service === "object" && service.price
+                                ? service.price
+                                : Math.round(total / services.length);
 
-                          return (
-                            <Badge
-                              key={idx}
-                              variant="secondary"
-                              className="bg-white text-gray-700 border border-blue-200 text-xs px-2 py-1"
-                            >
-                              {serviceName} {quantity > 1 && `x${quantity}`}
-                            </Badge>
-                          );
-                        })}
-                      </div>
-                    </div>
-
-                    {/* Schedule */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-4">
-                      <div className="p-2 sm:p-4 bg-green-50 rounded-lg border border-green-100">
-                        <div className="flex items-center gap-2 mb-1 sm:mb-2">
-                          <Calendar className="h-3 w-3 sm:h-4 sm:w-4 text-green-600" />
-                          <span className="font-medium text-gray-900 text-sm sm:text-base">
-                            Pickup
-                          </span>
-                        </div>
-                        <p className="text-xs sm:text-sm font-medium text-gray-900">
-                          {formatDate(
-                            booking.pickupDate || booking.scheduled_date,
-                          )}
-                        </p>
-                        <p className="text-xs text-green-600">
-                          {booking.pickupTime ||
-                            booking.scheduled_time ||
-                            "10:00"}
-                        </p>
-                      </div>
-
-                      <div className="p-2 sm:p-4 bg-emerald-50 rounded-lg border border-emerald-100">
-                        <div className="flex items-center gap-2 mb-1 sm:mb-2">
-                          <Calendar className="h-3 w-3 sm:h-4 sm:w-4 text-emerald-600" />
-                          <span className="font-medium text-gray-900 text-sm sm:text-base">
-                            Delivery
-                          </span>
-                        </div>
-                        <p className="text-xs sm:text-sm font-medium text-gray-900">
-                          {formatDate(booking.deliveryDate) || "Date TBD"}
-                        </p>
-                        <p className="text-xs text-emerald-600">
-                          {booking.deliveryTime || "18:00"}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Address */}
-                    <div className="p-4 bg-gray-50 rounded-lg border border-gray-100">
-                      <div className="flex items-start gap-3">
-                        <MapPin className="h-5 w-5 text-gray-600 mt-0.5" />
-                        <div>
-                          <p className="font-medium text-gray-900 mb-1">
-                            Service Address
-                          </p>
-                          <p className="text-sm text-gray-600 leading-relaxed">
-                            {typeof booking.address === "object" &&
-                            booking.address !== null
-                              ? booking.address.fullAddress ||
-                                [
-                                  booking.address.flatNo,
-                                  booking.address.street,
-                                  booking.address.landmark,
-                                  booking.address.village,
-                                  booking.address.city,
-                                  booking.address.pincode,
-                                ]
-                                  .filter(Boolean)
-                                  .join(", ") ||
-                                "Address not provided"
-                              : booking.address || "Address not provided"}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Price Breakdown */}
-                    <div className="p-4 bg-gradient-to-r from-green-50 to-emerald-50 rounded-lg border border-green-200">
-                      <h4 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
-                        <CreditCard className="h-4 w-4 text-green-600" />
-                        Price Breakdown
-                      </h4>
-
-                      <div className="space-y-2">
-                        <div className="flex justify-between items-center">
-                          <span className="text-sm text-gray-600">
-                            Services Total
-                          </span>
-                          <span className="font-medium">₹{total}</span>
-                        </div>
-
-                        {booking.discount_amount &&
-                          booking.discount_amount > 0 && (
-                            <div className="flex justify-between items-center">
-                              <span className="text-sm text-green-600">
-                                Discount
-                              </span>
-                              <span className="font-medium text-green-600">
-                                -₹{booking.discount_amount}
-                              </span>
-                            </div>
-                          )}
-
-                        <Separator />
-
-                        <div className="flex justify-between items-center">
-                          <span className="font-semibold text-gray-900">
-                            Total Amount
-                          </span>
-                          <span className="text-xl font-bold text-green-600">
-                            ₹{total}
-                          </span>
-                        </div>
-
-                        <div className="flex justify-between items-center">
-                          <span className="text-xs text-gray-500">
-                            Payment Status
-                          </span>
-                          <Badge
-                            variant={
-                              (booking.payment_status ||
-                                booking.paymentStatus) === "paid"
-                                ? "default"
-                                : "secondary"
-                            }
-                          >
-                            {(
-                              booking.payment_status ||
-                              booking.paymentStatus ||
-                              "pending"
-                            ).toUpperCase()}
-                          </Badge>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Actions */}
-
-                    <div className="flex flex-col gap-2 sm:gap-3 pt-2 sm:pt-4 border-t border-gray-200">
-                      {hasRealId ? (
-                        <>
-                          {/* Primary Actions Row */}
-                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3">
-                            {canEditBooking(booking) && (
-                              <Button
-                                onClick={() => handleEditBooking(booking)}
-                                variant="outline"
-                                className="flex items-center justify-center gap-1 sm:gap-2 border-green-200 text-green-600 hover:bg-green-50 py-1.5 sm:py-2 text-xs sm:text-sm"
-                                size="sm"
+                            return (
+                              <div
+                                key={idx}
+                                className="flex justify-between items-center bg-white p-2 rounded text-xs"
                               >
-                                <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
-                                <span>Edit Order</span>
-                              </Button>
+                                <span className="font-medium">
+                                  {serviceName}
+                                </span>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-gray-600">
+                                    Qty: {quantity}
+                                  </span>
+                                  <span className="font-semibold text-green-600">
+                                    ₹{price * quantity}
+                                  </span>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+
+                      {/* Schedule Details */}
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="p-3 bg-green-50 rounded-lg">
+                          <div className="flex items-center gap-2 mb-1">
+                            <Calendar className="h-3 w-3 text-green-600" />
+                            <span className="font-medium text-gray-900 text-xs">
+                              Pickup
+                            </span>
+                          </div>
+                          <p className="text-xs font-medium text-gray-900">
+                            {formatDate(
+                              booking.pickupDate || booking.scheduled_date,
                             )}
+                          </p>
+                          <p className="text-xs text-green-600">
+                            {booking.pickupTime ||
+                              booking.scheduled_time ||
+                              "10:00"}
+                          </p>
+                        </div>
+
+                        <div className="p-3 bg-emerald-50 rounded-lg">
+                          <div className="flex items-center gap-2 mb-1">
+                            <Calendar className="h-3 w-3 text-emerald-600" />
+                            <span className="font-medium text-gray-900 text-xs">
+                              Delivery
+                            </span>
+                          </div>
+                          <p className="text-xs font-medium text-gray-900">
+                            {formatDate(booking.deliveryDate) || "Date TBD"}
+                          </p>
+                          <p className="text-xs text-emerald-600">
+                            {booking.deliveryTime || "18:00"}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Address */}
+                      <div className="p-3 bg-gray-50 rounded-lg">
+                        <div className="flex items-start gap-2">
+                          <MapPin className="h-4 w-4 text-gray-600 mt-0.5 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="font-medium text-gray-900 mb-1 text-xs">
+                              Service Address
+                            </p>
+                            <p className="text-xs text-gray-600 leading-relaxed">
+                              {typeof booking.address === "object" &&
+                              booking.address !== null
+                                ? booking.address.fullAddress ||
+                                  [
+                                    booking.address.flatNo,
+                                    booking.address.street,
+                                    booking.address.landmark,
+                                    booking.address.village,
+                                    booking.address.city,
+                                    booking.address.pincode,
+                                  ]
+                                    .filter(Boolean)
+                                    .join(", ") ||
+                                  "Address not provided"
+                                : booking.address || "Address not provided"}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Price Breakdown */}
+                      <div className="p-3 bg-gradient-to-r from-green-50 to-emerald-50 rounded-lg">
+                        <h4 className="font-semibold text-gray-900 mb-2 text-xs flex items-center gap-2">
+                          <CreditCard className="h-3 w-3 text-green-600" />
+                          Price Breakdown
+                        </h4>
+
+                        <div className="space-y-1 text-xs">
+                          <div className="flex justify-between items-center">
+                            <span className="text-gray-600">
+                              Services Total
+                            </span>
+                            <span className="font-medium">₹{total}</span>
                           </div>
 
-                          {/* Secondary Actions Row */}
-                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                            {canCancelBooking(booking) && (
-                              <AlertDialog>
-                                <AlertDialogTrigger asChild>
-                                  <Button
-                                    variant="outline"
-                                    className="flex items-center justify-center gap-2 border-red-200 text-red-600 hover:bg-red-50 py-2"
-                                    disabled={cancellingBooking === bookingId}
-                                    size="sm"
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                    <span className="text-sm">
+                          {booking.discount_amount &&
+                            booking.discount_amount > 0 && (
+                              <div className="flex justify-between items-center">
+                                <span className="text-green-600">Discount</span>
+                                <span className="font-medium text-green-600">
+                                  -₹{booking.discount_amount}
+                                </span>
+                              </div>
+                            )}
+
+                          <Separator className="my-1" />
+
+                          <div className="flex justify-between items-center">
+                            <span className="font-semibold text-gray-900">
+                              Total Amount
+                            </span>
+                            <span className="font-bold text-green-600">
+                              ₹{total}
+                            </span>
+                          </div>
+
+                          <div className="flex justify-between items-center pt-1">
+                            <span className="text-gray-500">
+                              Payment Status
+                            </span>
+                            <Badge
+                              variant={
+                                (booking.payment_status ||
+                                  booking.paymentStatus) === "paid"
+                                  ? "default"
+                                  : "secondary"
+                              }
+                              className="text-xs"
+                            >
+                              {(
+                                booking.payment_status ||
+                                booking.paymentStatus ||
+                                "pending"
+                              ).toUpperCase()}
+                            </Badge>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Action Buttons */}
+                      <div className="space-y-2 pt-2 border-t">
+                        {hasRealId ? (
+                          <>
+                            <div className="grid grid-cols-2 gap-2">
+                              {canEditBooking(booking) && (
+                                <Button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleEditBooking(booking);
+                                  }}
+                                  variant="outline"
+                                  className="text-xs py-2 border-green-200 text-green-600 hover:bg-green-50"
+                                  size="sm"
+                                >
+                                  <Edit className="h-3 w-3 mr-1" />
+                                  Edit Order
+                                </Button>
+                              )}
+
+                              {canCancelBooking(booking) && (
+                                <AlertDialog>
+                                  <AlertDialogTrigger asChild>
+                                    <Button
+                                      variant="outline"
+                                      className="text-xs py-2 border-red-200 text-red-600 hover:bg-red-50"
+                                      disabled={cancellingBooking === bookingId}
+                                      size="sm"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <Trash2 className="h-3 w-3 mr-1" />
                                       {cancellingBooking === bookingId
                                         ? "Cancelling..."
                                         : "Cancel"}
-                                    </span>
-                                  </Button>
-                                </AlertDialogTrigger>
-                                <AlertDialogContent className="mx-4">
-                                  <AlertDialogHeader>
-                                    <AlertDialogTitle>
-                                      Cancel Booking?
-                                    </AlertDialogTitle>
-                                    <AlertDialogDescription>
-                                      Are you sure you want to cancel this
-                                      booking? This action cannot be undone.
-                                    </AlertDialogDescription>
-                                  </AlertDialogHeader>
-                                  <AlertDialogFooter className="flex-col sm:flex-row gap-2">
-                                    <AlertDialogCancel className="w-full sm:w-auto">
-                                      Keep Booking
-                                    </AlertDialogCancel>
-                                    <AlertDialogAction
-                                      onClick={() => {
-                                        console.log(
-                                          "🔥 Cancel button clicked for booking:",
-                                          {
-                                            bookingId,
-                                            hasBookingId: !!bookingId,
-                                            booking,
-                                          },
-                                        );
-                                        if (bookingId) {
-                                          handleCancelBooking(bookingId);
-                                        } else {
-                                          console.error(
-                                            "❌ No valid booking ID for cancellation",
-                                          );
-                                        }
-                                      }}
-                                      className="bg-red-600 hover:bg-red-700 w-full sm:w-auto"
-                                    >
-                                      Yes, Cancel Booking
-                                    </AlertDialogAction>
-                                  </AlertDialogFooter>
-                                </AlertDialogContent>
-                              </AlertDialog>
-                            )}
-                          </div>
+                                    </Button>
+                                  </AlertDialogTrigger>
+                                  <AlertDialogContent className="mx-4">
+                                    <AlertDialogHeader>
+                                      <AlertDialogTitle>
+                                        Cancel Booking?
+                                      </AlertDialogTitle>
+                                      <AlertDialogDescription>
+                                        Are you sure you want to cancel this
+                                        booking? This action cannot be undone.
+                                      </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter className="flex-col sm:flex-row gap-2">
+                                      <AlertDialogCancel className="w-full sm:w-auto">
+                                        Keep Booking
+                                      </AlertDialogCancel>
+                                      <AlertDialogAction
+                                        onClick={() => {
+                                          if (bookingId) {
+                                            handleCancelBooking(bookingId);
+                                          }
+                                        }}
+                                        className="bg-red-600 hover:bg-red-700 w-full sm:w-auto"
+                                      >
+                                        Yes, Cancel Booking
+                                      </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                  </AlertDialogContent>
+                                </AlertDialog>
+                              )}
+                            </div>
 
-                          {/* Contact Support */}
+                            <Button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleContactSupport(bookingId);
+                              }}
+                              variant="outline"
+                              className="w-full text-xs py-2 border-gray-200 text-gray-600 hover:bg-gray-50"
+                              size="sm"
+                            >
+                              <MessageCircle className="h-3 w-3 mr-1" />
+                              Contact Support
+                            </Button>
+                          </>
+                        ) : (
                           <Button
-                            onClick={() => handleContactSupport(bookingId)}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleContactSupport(bookingId);
+                            }}
                             variant="outline"
-                            className="flex items-center justify-center gap-2 border-gray-200 text-gray-600 hover:bg-gray-50 py-2"
+                            className="w-full text-xs py-2 border-gray-200 text-gray-600 hover:bg-gray-50"
                             size="sm"
                           >
-                            <MessageCircle className="h-3 w-3 sm:h-4 sm:w-4" />
-                            <span className="text-xs sm:text-sm">
-                              Contact Support
-                            </span>
+                            <MessageCircle className="h-3 w-3 mr-1" />
+                            Contact Support
                           </Button>
-                        </>
-                      ) : (
-                        <div className="grid grid-cols-1 gap-3">
-                          <Button
-                            onClick={() => handleContactSupport(bookingId)}
-                            variant="outline"
-                            className="flex items-center justify-center gap-2 border-gray-200 text-gray-600 hover:bg-gray-50 py-2"
-                            size="sm"
-                          >
-                            <MessageCircle className="h-3 w-3 sm:h-4 sm:w-4" />
-                            <span className="text-xs sm:text-sm">
-                              Contact Support
-                            </span>
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-                  </CardContent>
+                        )}
+                      </div>
+                    </CardContent>
+                  )}
                 </Card>
               );
             })}

--- a/src/components/LaundryCart.tsx
+++ b/src/components/LaundryCart.tsx
@@ -123,7 +123,7 @@ const LaundryCart: React.FC<LaundryCartProps> = ({
               setSpecialInstructions(state.specialInstructions);
             if (state.appliedCoupon) setAppliedCoupon(state.appliedCoupon);
 
-            console.log("✅ Restored checkout form state after login");
+            console.log("�� Restored checkout form state after login");
           }
           localStorage.removeItem("checkout_form_state");
         } catch (error) {
@@ -529,135 +529,137 @@ Confirm this booking?`;
         </div>
       </div>
 
-      <div className="p-2 space-y-3 pb-32">
-        {/* Cart Items */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm">Order Items</CardTitle>
+      <div className="p-2 space-y-2 pb-32">
+        {/* Cart Items - Compact View */}
+        <Card className="shadow-sm">
+          <CardHeader className="pb-1 px-3 py-2">
+            <CardTitle className="text-sm font-medium">
+              Items ({cartItems.length})
+            </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2 pt-0">
+          <CardContent className="space-y-1 pt-0 px-3 pb-3">
             {cartItems.map(({ service, quantity }) => (
-              <div key={service!.id} className="p-2 bg-gray-50 rounded-lg">
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 bg-gradient-to-br from-green-100 to-green-200 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <span className="text-sm">
-                      {service!.category.includes("Men")
-                        ? "👔"
-                        : service!.category.includes("Women")
-                          ? "👗"
-                          : service!.category.includes("Woolen")
-                            ? "🧥"
-                            : service!.category.includes("Steam")
-                              ? "🔥"
-                              : service!.category.includes("Iron")
-                                ? "🏷️"
-                                : "👕"}
-                    </span>
-                  </div>
+              <div
+                key={service!.id}
+                className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg"
+              >
+                <div className="w-6 h-6 bg-gradient-to-br from-green-100 to-green-200 rounded flex items-center justify-center flex-shrink-0">
+                  <span className="text-xs">
+                    {service!.category.includes("Men")
+                      ? "👔"
+                      : service!.category.includes("Women")
+                        ? "👗"
+                        : service!.category.includes("Woolen")
+                          ? "🧥"
+                          : service!.category.includes("Steam")
+                            ? "🔥"
+                            : service!.category.includes("Iron")
+                              ? "🏷️"
+                              : "👕"}
+                  </span>
+                </div>
 
-                  <div className="flex-1 min-w-0">
-                    <h4 className="font-medium text-xs truncate">
-                      {service!.name}
-                    </h4>
-                    <p className="text-xs text-green-600">₹{service!.price}</p>
-                  </div>
+                <div className="flex-1 min-w-0">
+                  <h4 className="font-medium text-xs truncate">
+                    {service!.name}
+                  </h4>
+                  <p className="text-xs text-green-600">₹{service!.price}</p>
+                </div>
 
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => updateQuantity(service!.id, -1)}
+                    className="h-5 w-5 p-0 text-xs"
+                  >
+                    <Minus className="h-2 w-2" />
+                  </Button>
+                  <span className="w-4 text-center font-medium text-xs">
+                    {quantity}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => updateQuantity(service!.id, 1)}
+                    className="h-5 w-5 p-0 text-xs"
+                  >
+                    <Plus className="h-2 w-2" />
+                  </Button>
+                </div>
+
+                <div className="flex items-center gap-1">
+                  <span className="font-semibold text-xs text-green-600">
+                    ₹{service!.price * quantity}
+                  </span>
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => removeItem(service!.id)}
-                    className="h-6 w-6 p-0 text-red-600 hover:text-red-700 hover:bg-red-50 flex-shrink-0"
+                    className="h-5 w-5 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>
-                </div>
-
-                <div className="flex items-center justify-between mt-1">
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => updateQuantity(service!.id, -1)}
-                      className="h-6 w-6 p-0"
-                    >
-                      <Minus className="h-3 w-3" />
-                    </Button>
-
-                    <span className="w-6 text-center font-medium text-xs">
-                      {quantity}
-                    </span>
-
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => updateQuantity(service!.id, 1)}
-                      className="h-6 w-6 p-0"
-                    >
-                      <Plus className="h-3 w-3" />
-                    </Button>
-                  </div>
-
-                  <p className="font-semibold text-sm">
-                    ₹{service!.price * quantity}
-                  </p>
                 </div>
               </div>
             ))}
           </CardContent>
         </Card>
 
-        {/* Saved Addresses Section */}
-        <Card>
-          <CardHeader>
+        {/* Enhanced Address Form - Compact */}
+        <Card className="shadow-sm">
+          <CardHeader className="pb-2 px-3 py-2">
             <div className="flex items-center justify-between">
-              <CardTitle className="text-base flex items-center gap-2">
-                <MapPin className="h-4 w-4" />
-                Delivery Address
+              <CardTitle className="text-sm flex items-center gap-2">
+                <MapPin className="h-3 w-3" />
+                Address
               </CardTitle>
               {currentUser && (
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={() => setShowSavedAddresses(true)}
-                  className="flex items-center gap-2"
+                  className="h-6 px-2 text-xs"
                 >
-                  <Plus className="h-4 w-4" />
-                  Saved Addresses
+                  <Plus className="h-3 w-3 mr-1" />
+                  Saved
                 </Button>
               )}
             </div>
           </CardHeader>
+          <CardContent className="px-3 pb-3 pt-0">
+            <EnhancedAddressForm
+              onAddressChange={setAddressData}
+              initialAddress={addressData}
+            />
+          </CardContent>
         </Card>
 
-        {/* Enhanced Address Form */}
-        <EnhancedAddressForm
-          onAddressChange={setAddressData}
-          initialAddress={addressData}
-        />
-
-        {/* Contact & Schedule Details */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
-              <Clock className="h-4 w-4" />
-              Contact & Schedule
+        {/* Contact & Schedule Details - Compact */}
+        <Card className="shadow-sm">
+          <CardHeader className="pb-2 px-3 py-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Clock className="h-3 w-3" />
+              Schedule
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-3 px-3 pb-3 pt-0">
             <div>
-              <Label htmlFor="phone">Phone Number *</Label>
+              <Label htmlFor="phone" className="text-xs">
+                Phone *
+              </Label>
               <Input
                 id="phone"
                 type="tel"
                 placeholder="Enter phone number"
                 value={phoneNumber}
                 onChange={(e) => setPhoneNumber(e.target.value)}
-                className="mt-1"
+                className="mt-1 h-8 text-sm"
               />
             </div>
 
-            <div className="space-y-2">
-              <Label>Pickup Schedule *</Label>
+            <div className="space-y-1">
+              <Label className="text-xs">Pickup Schedule *</Label>
               <ProfessionalDateTimePicker
                 selectedDate={selectedDate}
                 selectedTime={selectedTime}
@@ -667,90 +669,89 @@ Confirm this booking?`;
             </div>
 
             <div>
-              <Label htmlFor="instructions">
-                Special Instructions (Optional)
+              <Label htmlFor="instructions" className="text-xs">
+                Instructions (Optional)
               </Label>
               <Textarea
                 id="instructions"
-                placeholder="Any special instructions for pickup or cleaning"
+                placeholder="Special instructions..."
                 value={specialInstructions}
                 onChange={(e) => setSpecialInstructions(e.target.value)}
                 rows={2}
-                className="mt-1"
+                className="mt-1 text-sm"
               />
             </div>
           </CardContent>
         </Card>
 
-        {/* Bill Summary with Coupon */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Bill Summary</CardTitle>
+        {/* Bill Summary - Compact */}
+        <Card className="shadow-sm">
+          <CardHeader className="pb-2 px-3 py-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <CreditCard className="h-3 w-3" />
+              Summary
+            </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="flex justify-between">
+          <CardContent className="space-y-2 px-3 pb-3 pt-0">
+            <div className="flex justify-between text-sm">
               <span>Subtotal</span>
               <span>₹{getSubtotal()}</span>
             </div>
 
-            <div className="flex justify-between">
-              <span>Delivery Charges</span>
+            <div className="flex justify-between text-sm">
+              <span>Delivery</span>
               <span>₹{getDeliveryCharge()}</span>
             </div>
 
-            {/* Compact Coupon Section */}
-            <div className="py-2 border-t border-gray-100">
-              {!appliedCoupon ? (
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Coupon code"
-                    value={couponCode}
-                    onChange={(e) =>
-                      setCouponCode(e.target.value.toUpperCase())
-                    }
-                    className="flex-1 h-8 text-sm"
-                  />
-                  <Button
-                    onClick={applyCoupon}
-                    variant="outline"
-                    disabled={!couponCode.trim()}
-                    className="h-8 px-3 text-sm"
-                  >
-                    Apply
-                  </Button>
+            {/* Ultra Compact Coupon Section */}
+            {!appliedCoupon ? (
+              <div className="flex gap-1 pt-1">
+                <Input
+                  placeholder="Coupon"
+                  value={couponCode}
+                  onChange={(e) => setCouponCode(e.target.value.toUpperCase())}
+                  className="flex-1 h-7 text-xs"
+                />
+                <Button
+                  onClick={applyCoupon}
+                  variant="outline"
+                  disabled={!couponCode.trim()}
+                  className="h-7 px-2 text-xs"
+                >
+                  Apply
+                </Button>
+              </div>
+            ) : (
+              <div className="flex justify-between items-center text-sm">
+                <div className="flex items-center gap-1">
+                  <span className="text-green-700 font-medium text-xs">
+                    ✓ {appliedCoupon.code}
+                  </span>
+                  <span className="text-xs text-green-600">
+                    ({appliedCoupon.discount}%)
+                  </span>
                 </div>
-              ) : (
-                <div className="flex justify-between items-center">
-                  <div className="flex items-center gap-2">
-                    <span className="text-green-700 font-medium text-sm">
-                      ✓ {appliedCoupon.code}
-                    </span>
-                    <span className="text-xs text-green-600">
-                      ({appliedCoupon.discount}% off)
-                    </span>
-                  </div>
-                  <Button
-                    onClick={removeCoupon}
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 w-6 p-0 text-green-600 hover:bg-green-100"
-                  >
-                    ✕
-                  </Button>
-                </div>
-              )}
-            </div>
+                <Button
+                  onClick={removeCoupon}
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 w-5 p-0 text-green-600 hover:bg-green-100"
+                >
+                  ✕
+                </Button>
+              </div>
+            )}
 
             {appliedCoupon && (
-              <div className="flex justify-between text-green-600">
-                <span>Coupon Discount</span>
+              <div className="flex justify-between text-green-600 text-sm">
+                <span>Discount</span>
                 <span>-₹{getCouponDiscount()}</span>
               </div>
             )}
 
-            <hr />
+            <hr className="my-2" />
 
-            <div className="flex justify-between font-semibold text-lg">
+            <div className="flex justify-between font-semibold">
               <span>Total</span>
               <span className="text-green-600">₹{getTotal()}</span>
             </div>

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -55,6 +55,7 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
   const [refreshing, setRefreshing] = useState(false);
   const [editingBooking, setEditingBooking] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [expandedCard, setExpandedCard] = useState<string | null>(null);
 
   const loadBookings = async () => {
     if (!currentUser?.id && !currentUser?._id && !currentUser?.phone) {

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -553,10 +553,23 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                 },
               };
 
+              const bookingId = safeBooking.id || `booking_${index}`;
+              const isExpanded = expandedCard === bookingId;
+              const total =
+                safeBooking.totalAmount ||
+                safeBooking.total_price ||
+                safeBooking.final_amount ||
+                0;
+
+              const toggleExpand = () => {
+                setExpandedCard(isExpanded ? null : bookingId);
+              };
+
               return (
                 <Card
                   key={safeBooking.id || index}
-                  className="border-0 shadow-lg rounded-xl overflow-hidden bg-white/95 backdrop-blur-sm hover:shadow-xl transition-all duration-300"
+                  className="border-0 shadow-sm rounded-lg overflow-hidden bg-white/95 backdrop-blur-sm hover:shadow-md transition-all duration-200 cursor-pointer"
+                  onClick={toggleExpand}
                 >
                   <CardHeader className="pb-2 p-3 bg-gradient-to-r from-green-50 to-emerald-50">
                     <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2">

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -666,223 +666,176 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
 
                   {/* Expanded Content - Only Visible When Expanded */}
                   {isExpanded && (
-                    <CardContent className="px-3 pb-3 pt-2 space-y-3 bg-white" onClick={(e) => e.stopPropagation()}>
-                    {/* Booked Services */}
-                    {safeBooking.services &&
-                      Array.isArray(safeBooking.services) &&
-                      safeBooking.services.length > 0 && (
-                        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 p-2 rounded-lg border border-blue-200">
-                          <div className="flex items-center justify-between mb-1">
-                            <h4 className="font-semibold text-gray-900 text-xs">
-                              Services ({safeBooking.services.length})
-                            </h4>
-                            <span className="text-xs text-blue-600 font-medium">
-                              ₹
-                              {safeBooking.totalAmount ||
-                                safeBooking.total_price ||
-                                0}
-                            </span>
-                          </div>
-                          <div className="flex flex-wrap gap-1">
-                            {safeBooking.services.map(
-                              (service: any, idx: number) => (
-                                <Badge
-                                  key={idx}
-                                  variant="secondary"
-                                  className="bg-white text-gray-700 border border-blue-200 text-xs px-1.5 py-0.5"
-                                >
-                                  <SafeText>{service.name}</SafeText>
-                                  {service.quantity > 1 &&
-                                    ` x${service.quantity}`}
-                                </Badge>
-                              ),
-                            )}
-                          </div>
-                        </div>
-                      )}
-
-                    {/* Pickup & Delivery Slots */}
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className="p-2 bg-green-50 rounded-lg border border-green-100">
-                        <div className="flex items-center gap-1 mb-1">
-                          <Calendar className="h-3 w-3 text-green-600" />
-                          <span className="font-medium text-gray-900 text-xs">
-                            Pickup
-                          </span>
-                        </div>
-                        <p className="text-xs text-gray-900">
-                          {(() => {
-                            const dateStr =
-                              safeBooking.pickupDate ||
-                              safeBooking.scheduled_date;
-                            if (!dateStr) return "Date TBD";
-
-                            try {
-                              let date;
-                              if (dateStr.includes("-")) {
-                                // YYYY-MM-DD format - parse as local date
-                                const [year, month, day] = dateStr
-                                  .split("-")
-                                  .map(Number);
-                                date = new Date(year, month - 1, day);
-                              } else {
-                                date = new Date(dateStr);
-                              }
-
-                              // Validate date
-                              if (isNaN(date.getTime())) return "Date TBD";
-
-                              return date.toLocaleDateString("en-US", {
-                                weekday: "short",
-                                month: "short",
-                                day: "numeric",
-                              });
-                            } catch (error) {
-                              console.error(
-                                "Error parsing date:",
-                                dateStr,
-                                error,
-                              );
-                              return "Date TBD";
-                            }
-                          })()}
-                        </p>
-                        <p className="text-xs text-green-600">
-                          {safeBooking.pickupTime ||
-                            safeBooking.scheduled_time ||
-                            "10:00"}
-                        </p>
-                      </div>
-
-                      <div className="p-3 bg-emerald-50 rounded-xl border border-emerald-100">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Calendar className="h-4 w-4 text-emerald-600" />
-                          <span className="font-medium text-gray-900 text-sm">
-                            Delivery
-                          </span>
-                        </div>
-                        <p className="text-sm text-gray-900">
-                          {safeBooking.deliveryDate
-                            ? new Date(
-                                safeBooking.deliveryDate,
-                              ).toLocaleDateString("en-US", {
-                                weekday: "short",
-                                month: "short",
-                                day: "numeric",
-                              })
-                            : safeBooking.scheduled_date
-                              ? (() => {
-                                  // Calculate delivery date (next day after pickup)
-                                  const dateStr = safeBooking.scheduled_date;
-                                  let date;
-
-                                  if (dateStr && dateStr.includes("-")) {
-                                    const [year, month, day] =
-                                      dateStr.split("-");
-                                    date = new Date(
-                                      parseInt(year),
-                                      parseInt(month) - 1,
-                                      parseInt(day) + 1,
-                                    );
-                                  } else if (dateStr) {
-                                    date = new Date(dateStr);
-                                    date.setDate(date.getDate() + 1);
-                                  } else {
-                                    return "Date TBD";
-                                  }
-
-                                  return date.toLocaleDateString("en-US", {
-                                    weekday: "short",
-                                    month: "short",
-                                    day: "numeric",
-                                  });
-                                })()
-                              : "Date TBD"}
-                        </p>
-                        <p className="text-xs text-emerald-600">
-                          {safeBooking.deliveryTime || "Time TBD"}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Address */}
-                    <div className="flex items-start gap-3 p-3 bg-green-50/50 rounded-xl border border-green-100/50">
-                      <MapPin className="h-5 w-5 text-green-600 mt-0.5" />
-                      <div className="flex-1">
-                        <p className="font-medium text-gray-900 mb-1">
-                          Service Address
-                        </p>
-                        <p className="text-sm text-gray-600 leading-relaxed">
-                          <SafeText>
-                            {safeBooking.address || "Address not provided"}
-                          </SafeText>
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Price Breakdown */}
-                    <div className="space-y-3">
-                      <h4 className="font-semibold text-gray-900 text-sm">
-                        Price Breakdown
-                      </h4>
-
-                      <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl border border-green-200 p-4">
-                        {/* Service Total */}
-                        <div className="flex justify-between items-center mb-2">
-                          <span className="text-sm text-gray-600">
-                            Services Total
-                          </span>
-                          <span className="font-medium">
-                            ₹
-                            {(() => {
-                              const servicesTotal = safeBooking.services.reduce(
-                                (total: number, service: any) => {
-                                  return (
-                                    total +
-                                    (service.price * service.quantity || 0)
-                                  );
-                                },
-                                0,
-                              );
-                              return servicesTotal > 0
-                                ? servicesTotal
-                                : safeBooking.totalAmount ||
-                                    safeBooking.total_price ||
-                                    safeBooking.final_amount ||
-                                    0;
-                            })()}
-                          </span>
-                        </div>
-
-                        {/* Discount if applicable */}
-                        {safeBooking.discount_amount &&
-                          safeBooking.discount_amount > 0 && (
-                            <div className="flex justify-between items-center mb-2">
-                              <span className="text-sm text-green-600">
-                                Discount
-                              </span>
-                              <span className="font-medium text-green-600">
-                                -₹{safeBooking.discount_amount}
+                    <CardContent
+                      className="px-3 pb-3 pt-2 space-y-3 bg-white"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {/* Booked Services */}
+                      {safeBooking.services &&
+                        Array.isArray(safeBooking.services) &&
+                        safeBooking.services.length > 0 && (
+                          <div className="bg-gradient-to-r from-blue-50 to-indigo-50 p-2 rounded-lg border border-blue-200">
+                            <div className="flex items-center justify-between mb-1">
+                              <h4 className="font-semibold text-gray-900 text-xs">
+                                Services ({safeBooking.services.length})
+                              </h4>
+                              <span className="text-xs text-blue-600 font-medium">
+                                ₹
+                                {safeBooking.totalAmount ||
+                                  safeBooking.total_price ||
+                                  0}
                               </span>
                             </div>
-                          )}
-
-                        {/* Tax if applicable */}
-                        {safeBooking.charges_breakdown?.tax_amount && (
-                          <div className="flex justify-between items-center mb-2">
-                            <span className="text-sm text-gray-600">Tax</span>
-                            <span className="font-medium">
-                              ₹{safeBooking.charges_breakdown.tax_amount}
-                            </span>
+                            <div className="flex flex-wrap gap-1">
+                              {safeBooking.services.map(
+                                (service: any, idx: number) => (
+                                  <Badge
+                                    key={idx}
+                                    variant="secondary"
+                                    className="bg-white text-gray-700 border border-blue-200 text-xs px-1.5 py-0.5"
+                                  >
+                                    <SafeText>{service.name}</SafeText>
+                                    {service.quantity > 1 &&
+                                      ` x${service.quantity}`}
+                                  </Badge>
+                                ),
+                              )}
+                            </div>
                           </div>
                         )}
 
-                        <div className="border-t border-green-200 pt-2">
-                          <div className="flex justify-between items-center">
-                            <span className="font-semibold text-gray-900">
-                              Total Amount
+                      {/* Pickup & Delivery Slots */}
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="p-2 bg-green-50 rounded-lg border border-green-100">
+                          <div className="flex items-center gap-1 mb-1">
+                            <Calendar className="h-3 w-3 text-green-600" />
+                            <span className="font-medium text-gray-900 text-xs">
+                              Pickup
                             </span>
-                            <span className="text-xl font-bold text-green-600">
+                          </div>
+                          <p className="text-xs text-gray-900">
+                            {(() => {
+                              const dateStr =
+                                safeBooking.pickupDate ||
+                                safeBooking.scheduled_date;
+                              if (!dateStr) return "Date TBD";
+
+                              try {
+                                let date;
+                                if (dateStr.includes("-")) {
+                                  // YYYY-MM-DD format - parse as local date
+                                  const [year, month, day] = dateStr
+                                    .split("-")
+                                    .map(Number);
+                                  date = new Date(year, month - 1, day);
+                                } else {
+                                  date = new Date(dateStr);
+                                }
+
+                                // Validate date
+                                if (isNaN(date.getTime())) return "Date TBD";
+
+                                return date.toLocaleDateString("en-US", {
+                                  weekday: "short",
+                                  month: "short",
+                                  day: "numeric",
+                                });
+                              } catch (error) {
+                                console.error(
+                                  "Error parsing date:",
+                                  dateStr,
+                                  error,
+                                );
+                                return "Date TBD";
+                              }
+                            })()}
+                          </p>
+                          <p className="text-xs text-green-600">
+                            {safeBooking.pickupTime ||
+                              safeBooking.scheduled_time ||
+                              "10:00"}
+                          </p>
+                        </div>
+
+                        <div className="p-3 bg-emerald-50 rounded-xl border border-emerald-100">
+                          <div className="flex items-center gap-2 mb-2">
+                            <Calendar className="h-4 w-4 text-emerald-600" />
+                            <span className="font-medium text-gray-900 text-sm">
+                              Delivery
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-900">
+                            {safeBooking.deliveryDate
+                              ? new Date(
+                                  safeBooking.deliveryDate,
+                                ).toLocaleDateString("en-US", {
+                                  weekday: "short",
+                                  month: "short",
+                                  day: "numeric",
+                                })
+                              : safeBooking.scheduled_date
+                                ? (() => {
+                                    // Calculate delivery date (next day after pickup)
+                                    const dateStr = safeBooking.scheduled_date;
+                                    let date;
+
+                                    if (dateStr && dateStr.includes("-")) {
+                                      const [year, month, day] =
+                                        dateStr.split("-");
+                                      date = new Date(
+                                        parseInt(year),
+                                        parseInt(month) - 1,
+                                        parseInt(day) + 1,
+                                      );
+                                    } else if (dateStr) {
+                                      date = new Date(dateStr);
+                                      date.setDate(date.getDate() + 1);
+                                    } else {
+                                      return "Date TBD";
+                                    }
+
+                                    return date.toLocaleDateString("en-US", {
+                                      weekday: "short",
+                                      month: "short",
+                                      day: "numeric",
+                                    });
+                                  })()
+                                : "Date TBD"}
+                          </p>
+                          <p className="text-xs text-emerald-600">
+                            {safeBooking.deliveryTime || "Time TBD"}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Address */}
+                      <div className="flex items-start gap-3 p-3 bg-green-50/50 rounded-xl border border-green-100/50">
+                        <MapPin className="h-5 w-5 text-green-600 mt-0.5" />
+                        <div className="flex-1">
+                          <p className="font-medium text-gray-900 mb-1">
+                            Service Address
+                          </p>
+                          <p className="text-sm text-gray-600 leading-relaxed">
+                            <SafeText>
+                              {safeBooking.address || "Address not provided"}
+                            </SafeText>
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Price Breakdown */}
+                      <div className="space-y-3">
+                        <h4 className="font-semibold text-gray-900 text-sm">
+                          Price Breakdown
+                        </h4>
+
+                        <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl border border-green-200 p-4">
+                          {/* Service Total */}
+                          <div className="flex justify-between items-center mb-2">
+                            <span className="text-sm text-gray-600">
+                              Services Total
+                            </span>
+                            <span className="font-medium">
                               ₹
                               {(() => {
                                 const servicesTotal =
@@ -895,142 +848,198 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                                     },
                                     0,
                                   );
-                                const actualTotal =
-                                  servicesTotal > 0
-                                    ? servicesTotal
-                                    : safeBooking.final_amount ||
-                                      safeBooking.totalAmount ||
+                                return servicesTotal > 0
+                                  ? servicesTotal
+                                  : safeBooking.totalAmount ||
                                       safeBooking.total_price ||
+                                      safeBooking.final_amount ||
                                       0;
-                                return actualTotal;
                               })()}
                             </span>
                           </div>
-                          <div className="flex justify-between items-center mt-1">
-                            <span className="text-xs text-gray-500">
-                              Payment Status
-                            </span>
-                            <span
-                              className={`text-xs px-2 py-1 rounded-full ${
-                                (safeBooking.payment_status ||
-                                  safeBooking.paymentStatus) === "paid"
-                                  ? "bg-green-100 text-green-800"
-                                  : "bg-yellow-100 text-yellow-800"
-                              }`}
-                            >
-                              {(
-                                safeBooking.payment_status ||
-                                safeBooking.paymentStatus ||
-                                "pending"
-                              ).toUpperCase()}
-                            </span>
+
+                          {/* Discount if applicable */}
+                          {safeBooking.discount_amount &&
+                            safeBooking.discount_amount > 0 && (
+                              <div className="flex justify-between items-center mb-2">
+                                <span className="text-sm text-green-600">
+                                  Discount
+                                </span>
+                                <span className="font-medium text-green-600">
+                                  -₹{safeBooking.discount_amount}
+                                </span>
+                              </div>
+                            )}
+
+                          {/* Tax if applicable */}
+                          {safeBooking.charges_breakdown?.tax_amount && (
+                            <div className="flex justify-between items-center mb-2">
+                              <span className="text-sm text-gray-600">Tax</span>
+                              <span className="font-medium">
+                                ₹{safeBooking.charges_breakdown.tax_amount}
+                              </span>
+                            </div>
+                          )}
+
+                          <div className="border-t border-green-200 pt-2">
+                            <div className="flex justify-between items-center">
+                              <span className="font-semibold text-gray-900">
+                                Total Amount
+                              </span>
+                              <span className="text-xl font-bold text-green-600">
+                                ₹
+                                {(() => {
+                                  const servicesTotal =
+                                    safeBooking.services.reduce(
+                                      (total: number, service: any) => {
+                                        return (
+                                          total +
+                                          (service.price * service.quantity ||
+                                            0)
+                                        );
+                                      },
+                                      0,
+                                    );
+                                  const actualTotal =
+                                    servicesTotal > 0
+                                      ? servicesTotal
+                                      : safeBooking.final_amount ||
+                                        safeBooking.totalAmount ||
+                                        safeBooking.total_price ||
+                                        0;
+                                  return actualTotal;
+                                })()}
+                              </span>
+                            </div>
+                            <div className="flex justify-between items-center mt-1">
+                              <span className="text-xs text-gray-500">
+                                Payment Status
+                              </span>
+                              <span
+                                className={`text-xs px-2 py-1 rounded-full ${
+                                  (safeBooking.payment_status ||
+                                    safeBooking.paymentStatus) === "paid"
+                                    ? "bg-green-100 text-green-800"
+                                    : "bg-yellow-100 text-yellow-800"
+                                }`}
+                              >
+                                {(
+                                  safeBooking.payment_status ||
+                                  safeBooking.paymentStatus ||
+                                  "pending"
+                                ).toUpperCase()}
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
 
-                    {/* Additional Details */}
-                    {safeBooking.additional_details && (
-                      <div className="p-3 bg-amber-50 rounded-xl border border-amber-200">
-                        <p className="font-medium text-gray-900 mb-1">
-                          Additional Notes
-                        </p>
-                        <p className="text-sm text-gray-600">
-                          {(() => {
-                            if (
-                              typeof booking.additional_details === "string"
-                            ) {
-                              return booking.additional_details;
-                            }
-                            if (
-                              typeof booking.additional_details === "object" &&
-                              booking.additional_details
-                            ) {
-                              return JSON.stringify(booking.additional_details);
-                            }
-                            return "No additional details";
-                          })()}
-                        </p>
-                      </div>
-                    )}
+                      {/* Additional Details */}
+                      {safeBooking.additional_details && (
+                        <div className="p-3 bg-amber-50 rounded-xl border border-amber-200">
+                          <p className="font-medium text-gray-900 mb-1">
+                            Additional Notes
+                          </p>
+                          <p className="text-sm text-gray-600">
+                            {(() => {
+                              if (
+                                typeof booking.additional_details === "string"
+                              ) {
+                                return booking.additional_details;
+                              }
+                              if (
+                                typeof booking.additional_details ===
+                                  "object" &&
+                                booking.additional_details
+                              ) {
+                                return JSON.stringify(
+                                  booking.additional_details,
+                                );
+                              }
+                              return "No additional details";
+                            })()}
+                          </p>
+                        </div>
+                      )}
 
-                    {/* Comprehensive Actions */}
-                    <div className="space-y-2 pt-2">
-                      {/* Primary Actions Row */}
-                      <div className="grid grid-cols-2 gap-2">
-                        {(safeBooking.status === "pending" ||
-                          safeBooking.status === "confirmed") && (
-                          <>
+                      {/* Comprehensive Actions */}
+                      <div className="space-y-2 pt-2">
+                        {/* Primary Actions Row */}
+                        <div className="grid grid-cols-2 gap-2">
+                          {(safeBooking.status === "pending" ||
+                            safeBooking.status === "confirmed") && (
+                            <>
+                              <Button
+                                variant="outline"
+                                onClick={() => handleEditBooking(safeBooking)}
+                                className="flex-1 rounded-lg border border-green-200 hover:bg-green-50 text-green-600 text-xs py-2"
+                              >
+                                <Edit className="mr-1 h-3 w-3" />
+                                Edit
+                              </Button>
+
+                              <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                  <Button
+                                    variant="outline"
+                                    className="flex-1 rounded-lg border border-red-200 hover:bg-red-50 text-red-600 text-xs py-2"
+                                  >
+                                    <XCircle className="mr-1 h-3 w-3" />
+                                    Cancel
+                                  </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                  <AlertDialogHeader>
+                                    <AlertDialogTitle>
+                                      Cancel Booking
+                                    </AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                      Are you sure you want to cancel this
+                                      booking? This action cannot be undone.
+                                    </AlertDialogDescription>
+                                  </AlertDialogHeader>
+                                  <AlertDialogFooter>
+                                    <AlertDialogCancel>
+                                      Keep Booking
+                                    </AlertDialogCancel>
+                                    <AlertDialogAction
+                                      onClick={() =>
+                                        handleCancelBooking(safeBooking.id)
+                                      }
+                                      className="bg-red-600 hover:bg-red-700"
+                                    >
+                                      Yes, Cancel
+                                    </AlertDialogAction>
+                                  </AlertDialogFooter>
+                                </AlertDialogContent>
+                              </AlertDialog>
+                            </>
+                          )}
+
+                          {safeBooking.status === "completed" && (
                             <Button
                               variant="outline"
-                              onClick={() => handleEditBooking(safeBooking)}
-                              className="flex-1 rounded-lg border border-green-200 hover:bg-green-50 text-green-600 text-xs py-2"
+                              className="col-span-2 rounded-xl border-2 border-amber-200 hover:bg-amber-50 text-amber-600 font-medium py-3"
                             >
-                              <Edit className="mr-1 h-3 w-3" />
-                              Edit
+                              <Star className="mr-2 h-4 w-4" />
+                              Rate & Review Service
                             </Button>
+                          )}
+                        </div>
 
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <Button
-                                  variant="outline"
-                                  className="flex-1 rounded-lg border border-red-200 hover:bg-red-50 text-red-600 text-xs py-2"
-                                >
-                                  <XCircle className="mr-1 h-3 w-3" />
-                                  Cancel
-                                </Button>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent>
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>
-                                    Cancel Booking
-                                  </AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    Are you sure you want to cancel this
-                                    booking? This action cannot be undone.
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel>
-                                    Keep Booking
-                                  </AlertDialogCancel>
-                                  <AlertDialogAction
-                                    onClick={() =>
-                                      handleCancelBooking(safeBooking.id)
-                                    }
-                                    className="bg-red-600 hover:bg-red-700"
-                                  >
-                                    Yes, Cancel
-                                  </AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          </>
-                        )}
-
-                        {safeBooking.status === "completed" && (
+                        {/* Secondary Actions Row */}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                           <Button
-                            variant="outline"
-                            className="col-span-2 rounded-xl border-2 border-amber-200 hover:bg-amber-50 text-amber-600 font-medium py-3"
+                            variant="ghost"
+                            className="rounded-xl border border-gray-200 hover:bg-gray-50 text-gray-600 font-medium py-3"
                           >
-                            <Star className="mr-2 h-4 w-4" />
-                            Rate & Review Service
+                            <Phone className="mr-2 h-4 w-4" />
+                            Contact Support
                           </Button>
-                        )}
+                        </div>
                       </div>
-
-                      {/* Secondary Actions Row */}
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <Button
-                          variant="ghost"
-                          className="rounded-xl border border-gray-200 hover:bg-gray-50 text-gray-600 font-medium py-3"
-                        >
-                          <Phone className="mr-2 h-4 w-4" />
-                          Contact Support
-                        </Button>
-                      </div>
-                    </div>
-                  </CardContent>
+                    </CardContent>
+                  )}
                 </Card>
               );
             } catch (error) {

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -971,7 +971,10 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                             <>
                               <Button
                                 variant="outline"
-                                onClick={() => handleEditBooking(safeBooking)}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleEditBooking(safeBooking);
+                                }}
                                 className="flex-1 rounded-lg border border-green-200 hover:bg-green-50 text-green-600 text-xs py-2"
                               >
                                 <Edit className="mr-1 h-3 w-3" />
@@ -983,6 +986,7 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                                   <Button
                                     variant="outline"
                                     className="flex-1 rounded-lg border border-red-200 hover:bg-red-50 text-red-600 text-xs py-2"
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     <XCircle className="mr-1 h-3 w-3" />
                                     Cancel
@@ -1031,6 +1035,7 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                           <Button
                             variant="ghost"
+                            onClick={(e) => e.stopPropagation()}
                             className="rounded-xl border border-gray-200 hover:bg-gray-50 text-gray-600 font-medium py-3"
                           >
                             <Phone className="mr-2 h-4 w-4" />

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -34,6 +34,7 @@ import {
   RefreshCw,
   Star,
   ArrowLeft,
+  Package,
 } from "lucide-react";
 import { BookingService } from "@/services/bookingService";
 import { adaptiveBookingHelpers } from "@/integrations/adaptive/bookingHelpers";

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -571,24 +571,96 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                   className="border-0 shadow-sm rounded-lg overflow-hidden bg-white/95 backdrop-blur-sm hover:shadow-md transition-all duration-200 cursor-pointer"
                   onClick={toggleExpand}
                 >
-                  <CardHeader className="pb-2 p-3 bg-gradient-to-r from-green-50 to-emerald-50">
-                    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2">
+                  {/* Compact Card Header - Always Visible */}
+                  <CardHeader className="pb-2 px-3 py-3 bg-gradient-to-r from-green-50 to-emerald-50">
+                    <div className="flex items-center justify-between">
                       <div className="flex-1 min-w-0">
-                        <CardTitle className="text-sm sm:text-base font-bold text-gray-900 mb-1 truncate">
-                          {safeBooking.service}
-                        </CardTitle>
-                        <p className="text-xs sm:text-sm text-green-600 truncate font-medium">
-                          by {safeBooking.provider_name}
-                        </p>
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="font-semibold text-sm text-gray-900 truncate">
+                            <SafeText>{safeBooking.service}</SafeText>
+                          </h3>
+                          <Badge
+                            className={`${getStatusColor(safeBooking.status)} text-xs px-1.5 py-0.5`}
+                          >
+                            <SafeText>{safeBooking.status}</SafeText>
+                          </Badge>
+                        </div>
+
+                        {/* Quick Info Row */}
+                        <div className="flex items-center gap-3 text-xs text-gray-600">
+                          <div className="flex items-center gap-1">
+                            <Package className="h-3 w-3" />
+                            <span>
+                              {safeBooking.services.length} item
+                              {safeBooking.services.length > 1 ? "s" : ""}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            <span>
+                              {(() => {
+                                const dateStr =
+                                  safeBooking.pickupDate ||
+                                  safeBooking.scheduled_date;
+                                if (!dateStr) return "Date TBD";
+                                try {
+                                  let date;
+                                  if (dateStr.includes("-")) {
+                                    const [year, month, day] = dateStr
+                                      .split("-")
+                                      .map(Number);
+                                    date = new Date(year, month - 1, day);
+                                  } else {
+                                    date = new Date(dateStr);
+                                  }
+                                  if (isNaN(date.getTime())) return "Date TBD";
+                                  return date.toLocaleDateString("en-US", {
+                                    month: "short",
+                                    day: "numeric",
+                                  });
+                                } catch (error) {
+                                  return "Date TBD";
+                                }
+                              })()}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            <span>
+                              <SafeText>
+                                {safeBooking.pickupTime ||
+                                  safeBooking.scheduled_time ||
+                                  "10:00"}
+                              </SafeText>
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1 text-green-600 font-semibold">
+                            <span>₹{total}</span>
+                          </div>
+                        </div>
                       </div>
-                      <Badge
-                        className={`${getStatusColor(safeBooking.status)} border font-medium`}
-                      >
-                        {getStatusIcon(safeBooking.status)}
-                        <span className="ml-1 capitalize">
-                          {safeBooking.status}
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-400">
+                          {isExpanded ? "Less" : "More"}
                         </span>
-                      </Badge>
+                        <div
+                          className={`transform transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+                        >
+                          <svg
+                            className="h-4 w-4 text-gray-400"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M19 9l-7 7-7-7"
+                            />
+                          </svg>
+                        </div>
+                      </div>
                     </div>
                   </CardHeader>
 

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -664,7 +664,9 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                     </div>
                   </CardHeader>
 
-                  <CardContent className="space-y-2 p-3">
+                  {/* Expanded Content - Only Visible When Expanded */}
+                  {isExpanded && (
+                    <CardContent className="px-3 pb-3 pt-2 space-y-3 bg-white" onClick={(e) => e.stopPropagation()}>
                     {/* Booked Services */}
                     {safeBooking.services &&
                       Array.isArray(safeBooking.services) &&


### PR DESCRIPTION
This change transforms the booking history cards from a fixed layout to an expandable/collapsible design.

Changes made:
- Added expandedCard state to track which card is currently expanded
- Added toggleExpand function to handle card expansion/collapse
- Redesigned card header to show compact summary information (service name, status badge, item count, date, time, and total price)
- Made cards clickable to toggle expansion
- Moved detailed content (services, schedule, addresses, additional details, and actions) into an expandable section that only shows when card is expanded
- Updated card styling with reduced shadows and improved hover effects
- Added expand/collapse chevron icon in card header
- Reduced vertical spacing between cards from space-y-6 to space-y-3
- Added click event handling to prevent propagation on interactive elements within expanded content

The new design provides a cleaner, more compact view of booking history while still allowing users to access full details when needed.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/70e50ad23f584cbaa6497075c217a631/zenith-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>70e50ad23f584cbaa6497075c217a631</projectId>-->
<!--<branchName>zenith-garden</branchName>-->