### PR TITLE
Fix template literal syntax in SavedAddressesModal

### DIFF
--- a/src/components/SavedAddressesModal.tsx
+++ b/src/components/SavedAddressesModal.tsx
@@ -90,7 +90,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
       if (!currentUser?.id && !currentUser?._id && !currentUser?.phone) return;
 
       const userId = currentUser._id || currentUser.id || currentUser.phone;
-      localStorage.setItem(addresses_${userId}, JSON.stringify(newAddresses));
+      localStorage.setItem(`addresses_${userId}`, JSON.stringify(newAddresses));
       setAddresses(newAddresses);
     };
 

--- a/src/components/SavedAddressesModal.tsx
+++ b/src/components/SavedAddressesModal.tsx
@@ -76,7 +76,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
       if (!currentUser?.id && !currentUser?._id && !currentUser?.phone) return;
 
       const userId = currentUser._id || currentUser.id || currentUser.phone;
-      const savedAddresses = localStorage.getItem(addresses_${userId});
+      const savedAddresses = localStorage.getItem(`addresses_${userId}`);
 
       if (savedAddresses) {
         const parsed = JSON.parse(savedAddresses);

--- a/src/components/SavedAddressesModal.tsx
+++ b/src/components/SavedAddressesModal.tsx
@@ -145,7 +145,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
 
       const newAddress: AddressData = {
         ...address,
-        id: addr_${Date.now()}_${Math.random().toString(36).substr(2, 9)},
+        id: `addr_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
@@ -216,7 +216,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
                 <p className="text-sm text-gray-600">
                   {addresses.length === 0
                     ? "No saved addresses yet"
-                    : ${addresses.length} saved ${addresses.length === 1 ? "address" : "addresses"}}
+                    : `${addresses.length} saved ${addresses.length === 1 ? "address" : "addresses"}`}
                 </p>
                 <Button
                   onClick={() => setShowAddForm(true)}
@@ -245,7 +245,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
                                 {address.label}
                               </h4>
                               <span
-                                className={text-xs px-2 py-1 rounded-full border ${getAddressTypeColor(address.type || "other")}}
+                                className={`text-xs px-2 py-1 rounded-full border ${getAddressTypeColor(address.type || "other")}`}
                               >
                                 {address.type
                                   ? address.type.charAt(0).toUpperCase() +


### PR DESCRIPTION
Replace incorrect template literal syntax with proper backtick notation in SavedAddressesModal component.

Changes made:
- Fixed localStorage.getItem() call to use proper template literal syntax
- Fixed localStorage.setItem() call to use proper template literal syntax  
- Fixed address ID generation to use proper template literal syntax
- Fixed address count display text to use proper template literal syntax
- Fixed CSS className concatenation to use proper template literal syntax

All instances now use backticks (`) instead of the previous incorrect syntax.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/70e50ad23f584cbaa6497075c217a631/pixel-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>70e50ad23f584cbaa6497075c217a631</projectId>-->
<!--<branchName>pixel-den</branchName>-->